### PR TITLE
Support new admin-bro ValidationError parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Artem Zabolotnyi <1arteha1@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "admin-bro": ">=1.6.0-beta.11",
+    "admin-bro": ">=2.2.0",
     "admin-bro-expressjs": ">=0.4.0",
     "typeorm": ">=0.2.21"
   },
@@ -36,7 +36,7 @@
     "@types/chai": "^4.2.4",
     "@types/mocha": "^5.2.7",
     "@types/node": "12.0.10",
-    "admin-bro": "^1.6.0-beta.11",
+    "admin-bro": "^2.2.0",
     "admin-bro-expressjs": "^0.4.0",
     "chai": "^4.2.0",
     "class-validator": "^0.11.0",

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -253,7 +253,7 @@ export class Resource extends BaseResource
                         message: Object.values(error.constraints)[0],
                     }
                 }), {});
-                throw new ValidationError(`${this.name()} validation failed`, validationErrors);
+                throw new ValidationError(validationErrors);
             }
         }
     }
@@ -270,7 +270,7 @@ export class Resource extends BaseResource
         {
             if(error.name === "QueryFailedError")
             {
-                throw new ValidationError(`${this.name()} validation failed`, {
+                throw new ValidationError({
                     [error.column]: {
                         type: "schema error",
                         message: error.message


### PR DESCRIPTION
Hey! Version 2.2.0 of `admin-bro` changed the parameters to `ValidationError` so that there is no generic `message` as the first argument. This was done in [this commit](https://github.com/SoftwareBrothers/admin-bro/commit/6b937c3077a100fa9c16cdf3d9661b36c6c48277).

So, I removed the first argument and upgraded the `admin-bro` peer dependency to `>=2.2.0`.

However, I wasn't able to build the project nor run the tests (even before my changes). Is the TypeScript compilation also broken for you? I can try to fix it but I'm not at all familiar with the project.

Thanks for taking a look!